### PR TITLE
disclosed quantity has to be 0 when placing SL

### DIFF
--- a/py5paisa/order.py
+++ b/py5paisa/order.py
@@ -71,7 +71,7 @@ class Order:
         self.atmarket = atmarket
         self.remote_order_id = remote_order_id
         self.exch_order_id = exch_order_id
-        self.disqty = quantity
+        self.disqty = 0
         self.stoploss_price = stoploss_price
         self.is_stoploss_order = is_stoploss_order
         self.ioc_order = ioc_order


### PR DESCRIPTION
SL order is not sent to the exchange, so disclosed qty has to be 0, with the current API, it gives error when placing stop loss order