### PR TITLE
Fixed send_data method for WebSocket

### DIFF
--- a/py5paisa/py5paisa.py
+++ b/py5paisa/py5paisa.py
@@ -476,9 +476,12 @@ class FivePaisaClient:
         except Exception as e:
             log_response(e)
 
-    def send_data(self, open_: any):
+    def send_data(self, wspayload: dict):
         try:
-            self.ws.on_open = open_
+            if self.ws is not None:
+                self.ws.send(json.dumps(wspayload))
+            else:
+                log_response("Websocket Connection not established call connect method first")
         except Exception as e:
             log_response(e)
 


### PR DESCRIPTION
* The `on_open` method of underlying websocket object is already updated in connect method, not sure why currently `send_data` also updates it.

* The `send_data` method updates the `on_open` method of underlying websocket object, instead it should allow user to send data over websocket.

* This fix is needed to gracefully unsubscribe from the live stream feed, on an already existing websocket connection, after we create a payload from `Request_Feed` method

