### PR TITLE
Fix `Verify` to `verify` in headers

### DIFF
--- a/py5paisa/py5paisa.py
+++ b/py5paisa/py5paisa.py
@@ -286,7 +286,7 @@ class FivePaisaClient:
             else:
                 raise Exception("Invalid request type!")
             res = httpx.post(url, json=self.payload,
-                                    headers=HEADERS,Verify=False).json()
+                                    headers=HEADERS,verify=False).json()
             self.payload = GENERIC_PAYLOAD
 
             if req_type == "MS":


### PR DESCRIPTION
Passing header as `Verify=False` breaks the API with the below errror
```
post() got an unexpected keyword argument 'Verify'. Did you mean 'verify'?
```
This is PR fixes the typo from `Verify` to `verify`